### PR TITLE
proposed formatting updates to categorical_key_values.json 

### DIFF
--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -46,7 +46,7 @@
         "Physiotherapy",
         "Pioglitazone",
         "Resistance",
-        "Sedentary3week",
+        "Sedentary",
         "Social",
         "Stretching",
         "Walking",

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -274,7 +274,6 @@
         "CyclingMaxTest",
         "CyclingSubMax",
         "NA",
-        "Na",
         "RockportWalk",
         "Treadmill",
         "TreadmillMaxTest",

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -20,7 +20,6 @@
         "MotorAssistedCycling",
         "NA",
         "NoContact",
-        "Nocontact",
         "Nointervention",
         "PlaceboPill",
         "Sedentary5week",

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -382,7 +382,7 @@
         "VT1"
     ],
     "ExperimentalGroup3": [
-        "Aerobic3week",
+        "Aerobic",
         "Cognitive",
         "Diet",
         "MetabolicSyndromeControl",

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -254,9 +254,9 @@
         "Switching",
         "Verbal",
         "Volume",
-        "backward",
+        "Backward",
         "combined",
-        "forward",
+        "Forward",
         "serum"
     ],
     "ConversionToGarber2011": [

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -292,8 +292,7 @@
         "Mixed",
         "NA",
         "Older",
-        "YoungAdult",
-        "older"
+        "YoungAdult"
     ],
     "ChangeinFM": [
         "-0.01",

--- a/validation/categorical_key_values.json
+++ b/validation/categorical_key_values.json
@@ -22,7 +22,7 @@
         "NoContact",
         "Nointervention",
         "PlaceboPill",
-        "Sedentary5week",
+        "Sedentary",
         "Social",
         "Stretch",
         "Waitlist"


### PR DESCRIPTION
These are mostly minor formatting updates to categorical_key_values.json, to address duplicates with inconsistent formatting, to capitalize the first word of variable levels, or to simplify group names to be consistent with name of group a type. The proposed changes have been changed in the main google data sheet.